### PR TITLE
Add auto_ptr & std_map keys() method on Javascript

### DIFF
--- a/Lib/javascript/v8/std_auto_ptr.i
+++ b/Lib/javascript/v8/std_auto_ptr.i
@@ -1,0 +1,19 @@
+/*
+    The typemaps here allow to handle functions returning std::auto_ptr<>,
+    which is the most common use of this type. If you have functions taking it
+    as parameter, these typemaps can't be used for them and you need to do
+    something else (e.g. use shared_ptr<> which SWIG supports fully).
+ */
+
+%define %auto_ptr(TYPE)
+
+%typemap (out) std::auto_ptr<TYPE > %{
+   %set_output(SWIG_NewPointerObj($1.release(), $descriptor(TYPE *), SWIG_POINTER_OWN | %newpointer_flags));
+%}
+%template() std::auto_ptr<TYPE >;
+%enddef
+
+namespace std {
+   template <class T> class auto_ptr {};
+}
+

--- a/Lib/javascript/v8/std_map.i
+++ b/Lib/javascript/v8/std_map.i
@@ -61,6 +61,13 @@ namespace std {
                 std::map< K, T, C >::iterator i = self->find(key);
                 return i != self->end();
             }
+            std::vector<K> keys() {
+                std::vector<K> keys;
+                for (std::map<  K, T, C >::iterator it = self->begin(); it != self->end(); ++it) {
+                    keys.push_back(it->first);
+                }
+                return keys;
+            }
         }
     };
 


### PR DESCRIPTION
Swig  now generate a new method to access to the keys of st::map(s) on the javascript wrapping.
Swig with javascript now support getting values from an std::auto_ptr. Even if std::auto_ptr it less and less used, there still exist code that use them.
