### PR TITLE
Expose member variables of base classes wrapped as interfaces

### DIFF
--- a/Doc/Manual/Java.html
+++ b/Doc/Manual/Java.html
@@ -3648,6 +3648,13 @@ They are of course still available in the Java proxy class.
 </p>
 
 <p>
+<b>C# note:</b> unlike Java, C# interfaces can declare properties, so for C# the non-static member variables
+of the wrapped C++ class are additionally exposed as properties in the generated interface and can be accessed
+through an interface reference. Static methods, static variables, enums and constants are still only available
+in the C# proxy class as for Java. This was first added in SWIG-4.5.0.
+</p>
+
+<p>
 Wherever a class marked as an interface is used, such as the <tt>UseBases</tt> method in the example,
 the interface name is used as the type in the Java layer:
 </p>

--- a/Examples/test-suite/csharp/multiple_inheritance_interfaces_runme.cs
+++ b/Examples/test-suite/csharp/multiple_inheritance_interfaces_runme.cs
@@ -92,5 +92,12 @@ public class multiple_inheritance_interfaces_runme {
     d.ia("bye", false);
 
     UndesirablesSwigImpl.UndesiredStaticMethod(UndesirablesSwigImpl.UndesiredEnum.UndesiredEnum1);
+
+    // Non-static member variables are exposed as properties in the interface, so they are
+    // accessible through an interface reference to a derived class.
+    Undesirables undesirables = new UndesirablesDerived();
+    undesirables.UndesiredVariable = 42;
+    if (undesirables.UndesiredVariable != 42)
+      throw new Exception("UndesiredVariable not accessible via the Undesirables interface");
   }
 }

--- a/Examples/test-suite/multiple_inheritance_interfaces.i
+++ b/Examples/test-suite/multiple_inheritance_interfaces.i
@@ -66,7 +66,8 @@ struct V3 : IV1, IV2 {};
 #endif
 
 %inline %{
-// Don't put variables and enums into interface
+// Non-static member variables are exposed in the interface (as properties for C#), but static
+// members, enums and constants are not and remain available only via the proxy class.
 class Undesirables
 {
 public:

--- a/Source/Modules/csharp.cxx
+++ b/Source/Modules/csharp.cxx
@@ -304,6 +304,8 @@ public:
 
     allow_overloading();
     Swig_interface_feature_enable();
+    // C# interfaces can declare properties, so expose member variables in them too.
+    Swig_interface_propagate_variables_enable();
   }
 
   /* ---------------------------------------------------------------------
@@ -2565,6 +2567,9 @@ public:
     String *terminator_code = NewString("");
     bool is_interface =
       GetFlag(parentNode(n), "feature:interface") && !checkAttribute(n, "kind", "variable") && !static_flag && Getattr(n, "interface:owner") == 0;
+    // Non-static member variables of an interface class are declared as properties in the generated interface.
+    bool is_interface_variable = interface_class_code && GetFlag(parentNode(n), "feature:interface") && checkAttribute(n, "kind", "variable") && !static_flag &&
+                                 Getattr(n, "interface:owner") == 0;
 
     if (!proxy_flag)
       return;
@@ -2863,6 +2868,8 @@ public:
 
         // Start property declaration
         Printf(proxy_class_code, "  %s %s%s %s {", methodmods, static_flag ? "static " : "", variable_type, variable_name);
+        if (is_interface_variable)
+          Printf(interface_class_code, "  %s %s {", variable_type, variable_name);
       }
       generate_property_declaration_flag = false;
 
@@ -2881,6 +2888,8 @@ public:
         } else {
           Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarin typemap defined for %s\n", SwigType_str(cvariable_type, 0));
         }
+        if (is_interface_variable)
+          Printf(interface_class_code, " set;");
       } else {
         // Getter method
         if ((tm = Swig_typemap_lookup("csvarout", n, "", 0))) {
@@ -2896,6 +2905,8 @@ public:
         } else {
           Swig_warning(WARN_CSHARP_TYPEMAP_CSOUT_UNDEF, input_file, line_number, "No csvarout typemap defined for %s\n", SwigType_str(t, 0));
         }
+        if (is_interface_variable)
+          Printf(interface_class_code, " get;");
       }
     } else {
       // Normal function call
@@ -3182,6 +3193,8 @@ public:
 
     // End property declaration
     Printf(proxy_class_code, "\n  }\n\n");
+    if (interface_class_code && GetFlag(parentNode(n), "feature:interface") && Getattr(n, "interface:owner") == 0)
+      Printf(interface_class_code, " }\n");
 
     return SWIG_OK;
   }

--- a/Source/Modules/interface.cxx
+++ b/Source/Modules/interface.cxx
@@ -19,12 +19,20 @@
 
 static bool interface_feature_enabled = false;
 
+/* Whether member variables should be propagated to derived classes alongside methods. This is only
+ * wanted for languages whose interfaces can declare instance variables (e.g. C# properties), so it
+ * is enabled separately from the interface feature itself. */
+static bool interface_variables_enabled = false;
+
 /* -----------------------------------------------------------------------------
  * collect_interface_methods()
  *
  * Create a list of all the methods from the base classes of class n that are
  * marked as an interface. The resulting list is thus the list of methods that
  * need to be implemented in order for n to be non-abstract.
+ *
+ * When variable propagation is enabled, non-static member variables are
+ * collected too, so that derived classes can implement the interface property.
  * ----------------------------------------------------------------------------- */
 
 static List *collect_interface_methods(Node *n) {
@@ -38,7 +46,9 @@ static List *collect_interface_methods(Node *n) {
         if (Cmp(nodeType(child), "cdecl") == 0) {
           if (GetFlag(child, "feature:ignore") || Getattr(child, "interface:owner"))
             continue;  // skip methods propagated to bases
-          if (!checkAttribute(child, "kind", "function"))
+          bool is_function = checkAttribute(child, "kind", "function");
+          bool is_variable = interface_variables_enabled && checkAttribute(child, "kind", "variable");
+          if (!is_function && !is_variable)
             continue;
           if (checkAttribute(child, "storage", "static"))
             continue;  // accept virtual methods, non-virtual methods too... mmm??. Warn that the interface class has something that is not a virtual method?
@@ -211,4 +221,16 @@ void Swig_interface_propagate_methods(Node *n) {
 
 void Swig_interface_feature_enable() {
   interface_feature_enabled = true;
+}
+
+/* -----------------------------------------------------------------------------
+ * Swig_interface_propagate_variables_enable()
+ *
+ * Turn on propagation of member variables to derived classes so that they can
+ * be exposed as part of the interface. Only meaningful when the interface
+ * feature is also enabled.
+ * ----------------------------------------------------------------------------- */
+
+void Swig_interface_propagate_variables_enable() {
+  interface_variables_enabled = true;
 }

--- a/Source/Modules/swigmod.h
+++ b/Source/Modules/swigmod.h
@@ -440,6 +440,7 @@ void Swig_nested_name_unnamed_c_structs(Node *n);
 
 /* Interface feature */
 void Swig_interface_feature_enable();
+void Swig_interface_propagate_variables_enable();
 void Swig_interface_propagate_methods(Node *n);
 
 /* Miscellaneous */


### PR DESCRIPTION
When wrapping a class using multiple inheritance, eg `struct D : B, T`, in C++ to C# using %interface() or related macros from swiginterfaces.i, the goal is to make the API of the generated C# class D as close to D in C++ as possible, but previously D didn't include any member variables defined in T.

Do include them now, as C# supports declaring properties in interfaces.